### PR TITLE
Fix script to correctly get the value of dataFile

### DIFF
--- a/simulations/launcher.sh
+++ b/simulations/launcher.sh
@@ -2,9 +2,12 @@
 
 doSimulations(){
     dir=${1%.data}
+    echo ${dir}
+    file=$1
+    echo ${file}
     (
 
-	lmp -v name "${dir}" \
+        lmp -v name "${dir}" \
 	    -v dataFile "${file}" \
 	    -v Structure "${dir}" \
 	    -v seed_v "${seedV}" \

--- a/simulations/launcher.sh
+++ b/simulations/launcher.sh
@@ -2,9 +2,7 @@
 
 doSimulations(){
     dir=${1%.data}
-    echo ${dir}
     file=$1
-    echo ${file}
     (
 
         lmp -v name "${dir}" \


### PR DESCRIPTION
This pull request addresses an issue in the original script `launcher.sh` in `simulation`, where the `file` variable was not properly set, causing the script to fail. The proposed changes include setting the `file` variable to the input parameter `$1`. This should ensure the correct functioning of the `doSimulations` function.